### PR TITLE
Product Card with Stimulus in product_controller

### DIFF
--- a/app/javascript/barcode_scanner.js
+++ b/app/javascript/barcode_scanner.js
@@ -48,6 +48,9 @@ window.addEventListener('load', function () {
                 document.getElementById('product-form').submit();
                 document.getElementById('product-card').innerHTML = '';
                 document.getElementById('product-card').insertAdjacentHTML('beforeend', `<div style="background-color: red">${data.product.product_name} <br> <img src="${data.product.image_url}"> </div>`);
+                // Custom Event for Stimulus in product_controller.js (ask Thomas for help if needed)
+                const newProduct = { name: data.product.product_name, imageUrl: data.product.image_url };
+                document.dispatchEvent(new CustomEvent('product:created', { detail: { product: newProduct } }));
 
 
             } catch (error) {

--- a/app/javascript/controllers/product_controller.js
+++ b/app/javascript/controllers/product_controller.js
@@ -1,8 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="product"
 export default class extends Controller {
   connect() {
-    console.log("prout");
+    console.log('Product controller connected');
+    document.addEventListener('product:created', this.handleProductCreated.bind(this));
+  }
+
+  handleProductCreated(event) {
+    const newProduct = event.detail.product;
+    console.log(`New product created: ${newProduct.name} (${newProduct.imageUrl})`);
+
+    document.getElementById('product-card').innerHTML = '';
+    document.getElementById('product-card').insertAdjacentHTML('beforeend', `${newProduct.name} <br> <img src="${newProduct.imageUrl}">`);
   }
 }

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -49,7 +49,7 @@
     <%= f.submit "Create Product" %>
   <% end %>
 
-  <div id="product-card"></div>
+  <div id="product-card" style="background-color: red"></div>
 
   <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
 </body>


### PR DESCRIPTION
**Stimulus** was unable to listen to the '_submit_' event on the _product-form_ because of the automatic nature of this event and the absence of an actual _click_ on the _submit_ button in this case. The **solution** in this case has been to define a _newProduct_ constant and to create a new _CustomEvent_ in which I can **dispatch** it to the _product_controller_.

Once our _product_controller_ was able to read our **product information** (see console logs "New product created"), we can **display this information in the product-card** by inserting some _adjacent HTML_.

This merge should not be noticeable because the **functionality remains the same as before**, however the aim was to restructure the existing code to pass the product information to the **Stimulus** controller.