### PR TITLE
Solved Mobile Auto-Download Issue

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -35,6 +35,10 @@ class ProductsController < ApplicationController
       @product.tag_list.add("unknown material")
     end
     @product.save!
+    respond_to do |format|
+      format.html { redirect_to product_path(@product) }
+      format.json { render json: { id: @product.id } }
+    end
   end
 
   def show

--- a/app/javascript/barcode_scanner.js
+++ b/app/javascript/barcode_scanner.js
@@ -39,7 +39,7 @@ window.addEventListener('load', function () {
                 // Different ways to get the material of the product
                 console.log(data?.product?.packagings[0]?.material ?? 'Information non disponible');
                 console.log(data?.product?.packaging_tags ?? 'Information non disponible');
-              
+
                 // Fill Form with product data
                 document.getElementById('product_name').value = data.product.product_name;
                 document.getElementById('product_image_url').value = data.product.image_url;
@@ -50,7 +50,19 @@ window.addEventListener('load', function () {
                 document.getElementById('product_description').value = description;
 
                 // Form Auto-Submit
-                document.getElementById('product-form').submit();
+                // document.getElementById('product-form').submit();
+                const form = document.getElementById('product-form');
+
+                const url = form.action;
+                const formData = new FormData(form);
+                fetch(url, {
+                  method: 'POST',
+                  'Accept': 'application/json',
+                  body: formData
+                })
+                .then(response => response.json())
+                .then(data => console.log(data))
+
                 document.getElementById('product-card').innerHTML = '';
 
                 // Custom Event for Stimulus in product_controller.js (ask Thomas for help if needed)

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -40,7 +40,7 @@
 
   <%# Form is not displayed but is used to create products seemlessly in the background %>
   <div style="display: none">
-    <%= form_with(model: [@user, @product], local: true, id: "product-form") do |f| %>
+    <%= form_with(model: @product, url: products_path( format: :json ), method: :post, local: true, id: "product-form") do |f| %>
       <%= f.label :name %>
       <%= f.text_field :name, id: "product_name" %>
       <%= f.label :image_url %>


### PR DESCRIPTION
**Auto-submit** triggered a **download** in production. To prevent this, the **auto-submit** of the form has been reworked in the _barcode_scanner.js_ file.