### PR TITLE
Configured NGROK and added all subdomains as allowed hosts with RegEx

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Add ngrok subdomain to allowed hosts (See Thomas for help if needed)
+  # Command line ==> ngrok http http://localhost:3000
+  Rails.application.config.hosts << /.*\.ngrok-free\.app/
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,8 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Add ngrok subdomain to allowed hosts (See Thomas for help if needed)
+  # Command line ==> ngrok http http://localhost:3000
+  Rails.application.config.hosts << /.*\.ngrok-free\.app/
 end


### PR DESCRIPTION
```
# Command line ==> ngrok http http://localhost:3000
Rails.application.config.hosts << /.*\.ngrok-free\.app/
```
Configured NGROK and added all subdomains as allowed hosts with RegEx. As we will be using NGROK's free ephemeral domains, the use of a RegEx should allow for no further adjusting and make everyone's life simpler.